### PR TITLE
[WIP] Register usable content type from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# eZ Platform File Based Content Types
+
+Allows Content Types to be defined in PHP classes.
+
+## Usage
+
+In `app/config/services.yml`:
+
+```yaml
+services:
+    _defaults:
+    AppBundle\Platform\ContentTypes\:
+        resource: '../../src/AppBundle/Platform/ContentTypes/*'
+        tags: [ezplatform.content_type_provider]
+```
+
+In `src/AppBundle/Platform/ContentTypes/MyContentType`:
+```php
+namespace AppBundle\Platform\ContentTypes;
+
+use BD\EzPlatformFileBasedContentType\ContentTypeProvider;
+use eZ\Publish\SPI;
+
+class BlogPostContentType implements ContentTypeProvider
+{
+    public function getType()
+    {
+        $type = new SPI\Persistence\Content\Type();
+
+        $type->id = 18;
+        $type->status = SPI\Persistence\Content\Type::STATUS_DEFINED;
+        $type->name = ['eng-GB' => 'Blog post'];
+        $type->description = ['A Blog post written by an author'];
+        $type->identifier = 'blog_post';
+        $type->created = 1528882990;
+        $type->modified = 1528882990;
+        $type->creatorId = '14';
+        $type->modifierId = '14';
+        $type->remoteId = 'b9dfe86b6188e504d64f3369d29350d5';
+        $type->urlAliasSchema = null;
+        $type->nameSchema = '<short_title|title>';
+        $type->isContainer = false;
+        $type->initialLanguageId = 2;
+        $type->sortField = SPI\Persistence\Content\Location::SORT_FIELD_PUBLISHED;
+        $type->sortOrder = SPI\Persistence\Content\Location::SORT_ORDER_DESC;
+        $type->groupIds = [1];
+        $type->fieldDefinitions = [];
+        $type->defaultAlwaysAvailable = false;
+
+        return $type;
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -18,40 +18,4 @@ services:
         tags: [ezplatform.content_type_provider]
 ```
 
-In `src/AppBundle/Platform/ContentTypes/MyContentType`:
-```php
-namespace AppBundle\Platform\ContentTypes;
-
-use BD\EzPlatformFileBasedContentType\ContentTypeProvider;
-use eZ\Publish\SPI;
-
-class BlogPostContentType implements ContentTypeProvider
-{
-    public function getType()
-    {
-        $type = new SPI\Persistence\Content\Type();
-
-        $type->id = 18;
-        $type->status = SPI\Persistence\Content\Type::STATUS_DEFINED;
-        $type->name = ['eng-GB' => 'Blog post'];
-        $type->description = ['A Blog post written by an author'];
-        $type->identifier = 'blog_post';
-        $type->created = 1528882990;
-        $type->modified = 1528882990;
-        $type->creatorId = '14';
-        $type->modifierId = '14';
-        $type->remoteId = 'b9dfe86b6188e504d64f3369d29350d5';
-        $type->urlAliasSchema = null;
-        $type->nameSchema = '<short_title|title>';
-        $type->isContainer = false;
-        $type->initialLanguageId = 2;
-        $type->sortField = SPI\Persistence\Content\Location::SORT_FIELD_PUBLISHED;
-        $type->sortOrder = SPI\Persistence\Content\Location::SORT_ORDER_DESC;
-        $type->groupIds = [1];
-        $type->fieldDefinitions = [];
-        $type->defaultAlwaysAvailable = false;
-
-        return $type;
-    }
-}
-```
+Create `src/AppBundle/Platform/ContentTypes/MyContentType`, and use [`tests/Fixtures/BlogPostContentType.php`](https://github.com/bdunogier/ezplatform-filebased-contenttypes/blob/prototype1/tests/Fixtures/BlogPostContentType.php) as a basis.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Allows Content Types to be defined in PHP classes.
 
+Can be used to define packages that automatically define content types they need.
+By defining a "blog_post" Content Type, a template and controllers for displaying
+blob posts on the frontend can be published and re-used.
+
 ## Usage
 
 In `app/config/services.yml`:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ blob posts on the frontend can be published and re-used.
 
 In `app/config/services.yml`:
 
-```yaml
+```yml
 services:
-    _defaults:
+    # ...
+
     AppBundle\Platform\ContentTypes\:
         resource: '../../src/AppBundle/Platform/ContentTypes/*'
         tags: [ezplatform.content_type_provider]

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bdunogier/ezplatform-filebased-contenttype",
+    "name": "bdunogier/ezplatform-filebased-contenttypes",
     "description": "An eZ Platform package that allows to define Content Types from files, without writing the to the Repository.",
     "type": "ezplatform-bundle",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,18 @@
     "name": "bdunogier/ezplatform-filebased-contenttypes",
     "description": "An eZ Platform package that allows to define Content Types from files, without writing the to the Repository.",
     "type": "ezplatform-bundle",
+    "autoload": {
+        "psr-4": {
+            "BD\\EzPlatformFileBasedContentType\\": "src/"	
+        }
+    },
     "require": {
         "ezsystems/ezpublish-kernel": "^7.0"
     },
     "require-dev": {
         "behat/behat": "^3.4"
     },
-    "license": "BSD",
+    "license": "LGPL-2.0-or-later",
     "authors": [
         {
             "name": "Bertrand Dunogier",

--- a/doc/features/prototype1.md
+++ b/doc/features/prototype1.md
@@ -1,0 +1,3 @@
+- [x] First prototype that adds classes based on PHP files to what the API returns.
+- [ ] Define bundle & service
+- [ ] Compiler pass that detects ContentTypes on disk and adds them to the service

--- a/doc/features/prototype1.md
+++ b/doc/features/prototype1.md
@@ -1,3 +1,3 @@
 - [x] First prototype that adds classes based on PHP files to what the API returns.
-- [ ] Define bundle & service
-- [ ] Compiler pass that detects ContentTypes on disk and adds them to the service
+- [x] Define bundle & service
+- [x] Compiler pass that detects ContentTypes on disk and adds them to the service

--- a/src/Bridge/Symfony/Bundle/BDEzPlatformGraphQLBundle.php
+++ b/src/Bridge/Symfony/Bundle/BDEzPlatformGraphQLBundle.php
@@ -1,0 +1,9 @@
+<?php
+namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class BDEzPlatformFileBasedContentTypeBundle extends Bundle
+{
+
+}

--- a/src/Bridge/Symfony/Bundle/BDEzPlatformGraphQLBundle.php
+++ b/src/Bridge/Symfony/Bundle/BDEzPlatformGraphQLBundle.php
@@ -1,9 +1,0 @@
-<?php
-namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle;
-
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-
-class BDEzPlatformFileBasedContentTypeBundle extends Bundle
-{
-
-}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/RegisterContentTypesClassesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/RegisterContentTypesClassesPass.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 13/06/2018
+ * Time: 13:12
+ */
+
+namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection;
+
+class RegisterContentTypesClassesPass implements DependencyInjection\Compiler\CompilerPassInterface
+{
+    const TAG = 'ezplatform.content_type_provider';
+    const HANDLER_SERVICE_ID = 'BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence\ContentTypeHandler';
+
+    public function process(DependencyInjection\ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::HANDLER_SERVICE_ID)) {
+            return;
+        }
+
+        $contentTypeProviders = [];
+        foreach ($container->findTaggedServiceIds(self::TAG) as $taggedServiceId => $tags) {
+            foreach ($tags as $tag) {
+                $contentTypeProviders[] = new DependencyInjection\Reference($taggedServiceId);
+            }
+        }
+
+        $handlerDefinition = $container->getDefinition(self::HANDLER_SERVICE_ID);
+        $handlerDefinition->setArgument('$typesProviders', $contentTypeProviders);
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/EzPlatformFileBasedContentTypesExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/EzPlatformFileBasedContentTypesExtension.php
@@ -1,0 +1,16 @@
+<?php
+namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class EzPlatformFileBasedContentTypesExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/Bridge/Symfony/Bundle/EzPlatformFileBasedContentTypesBundle.php
+++ b/src/Bridge/Symfony/Bundle/EzPlatformFileBasedContentTypesBundle.php
@@ -1,0 +1,8 @@
+<?php
+namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle;
+
+use Symfony\Component\HttpKernel;
+
+class EzPlatformFileBasedContentTypesBundle extends HttpKernel\Bundle\Bundle
+{
+}

--- a/src/Bridge/Symfony/Bundle/EzPlatformFileBasedContentTypesBundle.php
+++ b/src/Bridge/Symfony/Bundle/EzPlatformFileBasedContentTypesBundle.php
@@ -1,8 +1,15 @@
 <?php
 namespace BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle;
 
+use BD\EzPlatformFileBasedContentType\Bridge\Symfony\Bundle\DependencyInjection\Compiler\RegisterContentTypesClassesPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel;
 
 class EzPlatformFileBasedContentTypesBundle extends HttpKernel\Bundle\Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterContentTypesClassesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
+    }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yml
@@ -3,11 +3,12 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+    _instanceof:
+        BD\EzPlatformFileBasedContentType\ContentTypeProvider:
+            tags: [ezplatform.content_type_provider]
 
     BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence\ContentTypeHandler:
         decorates: ezpublish.spi.persistence.legacy.content_type.handler.inner
         arguments:
             - '@BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence\ContentTypeHandler.inner'
-            -
-                17: 'AppBundle\Platform\ContentTypes\FileBasedTestContentType'
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence\ContentTypeHandler:
+        decorates: ezpublish.spi.persistence.legacy.content_type.handler.inner
+        arguments:
+            - '@BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence\ContentTypeHandler.inner'
+            -
+                17: 'AppBundle\Platform\ContentTypes\FileBasedTestContentType'
+

--- a/src/ContentTypeProvider.php
+++ b/src/ContentTypeProvider.php
@@ -1,0 +1,10 @@
+<?php
+namespace BD\EzPlatformFileBasedContentType;
+
+interface ContentTypeProvider
+{
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Type
+     */
+    public function getType();
+}

--- a/src/Platform/SPI/Persistence/ContentTypeHandler.php
+++ b/src/Platform/SPI/Persistence/ContentTypeHandler.php
@@ -209,7 +209,7 @@ class ContentTypeHandler implements SPI\Handler
      */
     private function newType(array $parameters)
     {
-        return $this->typesById($this->extractId($parameters));
+        return $this->typesById[$this->extractId($parameters)];
     }
 
     /**
@@ -238,7 +238,7 @@ class ContentTypeHandler implements SPI\Handler
         extract($parameters);
 
         if (isset($identifier) && is_string($identifier)) {
-            if (!isset($this->typesByRemoteId[$identifier])) {
+            if (!isset($this->typesIdsByIdentifier[$identifier])) {
                 throw new InvalidArgumentException(
                     'identifier',
                     'No File based content type with this identifier'

--- a/src/Platform/SPI/Persistence/ContentTypeHandler.php
+++ b/src/Platform/SPI/Persistence/ContentTypeHandler.php
@@ -1,0 +1,277 @@
+<?php
+namespace BD\EzPlatformFileBasedContentType\Platform\SPI\Persistence;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\Persistence\Content\Type as SPI;
+use eZ\Publish\SPI\Persistence\Content\Type as SpiType;
+
+/**
+ * Glossary
+ * - CT: Content Type
+ * - FBCT: File Based Content Type
+ */
+class ContentTypeHandler implements SPI\Handler
+{
+    /**
+     * @var SPI\Handler
+     */
+    private $innerHandler;
+
+    /**
+     * File based content type classes, indexed by {@see self::$innerHandler} compatible id.
+     * @var array
+     */
+    private $typesById = [];
+
+    /**
+     * Map of {@see self::$typesBy} by identifier.
+     * @var string[]
+     */
+    private $typesIdsByIdentifier = [];
+
+    public function __construct(SPI\Handler $innerHandler, array $contentTypes = [])
+    {
+        $this->innerHandler = $innerHandler;
+        $this->typesById = $contentTypes;
+    }
+
+    /**
+     * @param mixed $groupId
+     * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type[]
+     */
+    public function loadContentTypes($groupId, $status = SpiType::STATUS_DEFINED)
+    {
+        $persistenceContentTypes = $this->innerHandler->loadContentTypes($groupId, $status);
+
+        foreach ($this->typesById as $typeClass) {
+            $type = (new $typeClass)->getType();
+            if (in_array($groupId, $type->groupIds)) {
+                $persistenceContentTypes[] = $type;
+            }
+        }
+
+        return $persistenceContentTypes;
+    }
+
+    public function load($contentTypeId, $status = SpiType::STATUS_DEFINED)
+    {
+        try {
+            return $this->innerHandler->load($contentTypeId, $status);
+        }
+        catch (NotFoundException $notFoundException) {
+            $parameters = ['id' => $contentTypeId];
+            if ($this->hasType($parameters)) {
+                return $this->newType($parameters);
+            }
+
+            throw $notFoundException;
+        }
+    }
+
+    /**
+     * @param string $identifier
+     * @return SpiType
+     * @throws InvalidArgumentException
+     * @throws NotFoundException
+     */
+    public function loadByIdentifier($identifier)
+    {
+        try {
+            return $this->innerHandler->loadByIdentifier($identifier);
+        }
+        catch (NotFoundException $notFoundException) {
+            $parameters = ['identifier' => $identifier];
+            if ($this->hasType($parameters)) {
+                return $this->newType($parameters);
+            }
+
+            throw $notFoundException;
+        }
+    }
+
+    /**
+     * @param mixed $remoteId
+     * @return SpiType
+     * @throws InvalidArgumentException
+     * @throws NotFoundException
+     */
+    public function loadByRemoteId($remoteId)
+    {
+        try {
+            return $this->innerHandler->loadByRemoteId($remoteId);
+        }
+        catch (NotFoundException $notFoundException) {
+            $parameters = ['remoteId' => $remoteId];
+            if ($this->hasType($parameters)) {
+                return $this->newType($parameters);
+            }
+
+            throw $notFoundException;
+        }
+    }
+
+    public function create(SPI\CreateStruct $contentType)
+    {
+        return $this->innerHandler->create($contentType);
+    }
+
+    public function update($contentTypeId, $status, SPI\UpdateStruct $contentType)
+    {
+        return $this->innerHandler->update($contentTypeId, $status, $contentType);
+    }
+
+    public function delete($contentTypeId, $status)
+    {
+        $this->innerHandler->delete($contentTypeId, $status);
+    }
+
+    public function createDraft($modifierId, $contentTypeId)
+    {
+        return $this->innerHandler->createDraft($modifierId, $contentTypeId);
+    }
+
+    public function copy($userId, $contentTypeId, $status)
+    {
+        /**
+         * @todo loading the copied CT is done inside the implementation.
+         *       Figure how to allow copy from file to repository.
+        return $this->innerHandler->copy($userId, $contentTypeId, $status);
+         */
+    }
+
+    public function unlink($groupId, $contentTypeId, $status)
+    {
+        $this->innerHandler->link($groupId, $contentTypeId, $status);
+    }
+
+    public function link($groupId, $contentTypeId, $status)
+    {
+        $this->innerHandler->link($groupId, $contentTypeId, $status);
+    }
+
+    public function getFieldDefinition($id, $status)
+    {
+        return $this->innerHandler->getFieldDefinition($id, $status);
+    }
+
+
+    public function getContentCount($contentTypeId)
+    {
+        return $this->innerHandler->getContentCount($contentTypeId);
+    }
+
+
+    public function addFieldDefinition($contentTypeId, $status, SPI\FieldDefinition $fieldDefinition)
+    {
+        return $this->innerHandler->addFieldDefinition($contentTypeId, $status, $fieldDefinition);
+    }
+
+    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId)
+    {
+        return $this->innerHandler->removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId);
+    }
+
+    public function updateFieldDefinition($contentTypeId, $status, SPI\FieldDefinition $fieldDefinition)
+    {
+        return $this->innerHandler->updateFieldDefinition($contentTypeId, $status, $fieldDefinition);
+    }
+
+    public function publish($contentTypeId)
+    {
+        return $this->innerHandler->publish($contentTypeId);
+    }
+
+    public function getSearchableFieldMap()
+    {
+        return $this->innerHandler->getSearchableFieldMap();
+    }
+
+    /**
+     * @param array $parameters
+     * @return SpiType
+     * @throws InvalidArgumentException
+     */
+    private function newType(array $parameters)
+    {
+        $builder = $this->typesById($this->extractId($parameters));
+
+        return (new $builder)->getType();
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException
+     */
+    private function hasType(array $parameters)
+    {
+        $id = $this->extractId($parameters);
+
+        return (isset($this->typesById[$id]));
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return int|string
+     *
+     * @throws InvalidArgumentException
+     */
+    private function extractId(array $parameters)
+    {
+        extract($parameters);
+
+        if (isset($identifier) && is_string($identifier)) {
+            $id = $this->typesIdsByIdentifier[$identifier];
+        } else if (isset($remoteId)) {
+            $id = $remoteId;
+        } else if (!isset($id)) {
+            throw new InvalidArgumentException(
+                'parameters',
+                "Must contain one of 'id', 'identifiers' or 'remoteId'"
+            );
+        }
+
+        return $id;
+    }
+
+    public function createGroup(SPI\Group\CreateStruct $group)
+    {
+        return $this->innerHandler->createGroup($group);
+    }
+
+    public function updateGroup(SPI\Group\UpdateStruct $group)
+    {
+        $this->innerHandler->updateGroup($group);
+    }
+
+    public function deleteGroup($groupId)
+    {
+        $this->innerHandler->deleteGroup($groupId);
+    }
+
+    public function loadGroup($groupId)
+    {
+        return $this->innerHandler->loadGroup($groupId);
+    }
+
+    public function loadGroups(array $groupIds)
+    {
+        return $this->innerHandler->loadGroups($groupIds);
+    }
+
+    public function loadGroupByIdentifier($identifier)
+    {
+        return $this->innerHandler->loadGroupByIdentifier($identifier);
+    }
+
+    public function loadAllGroups()
+    {
+        return $this->innerHandler->loadAllGroups();
+    }
+}

--- a/tests/Fixtures/BlogPostContentType.php
+++ b/tests/Fixtures/BlogPostContentType.php
@@ -1,0 +1,59 @@
+<?php
+namespace BD\Tests\EzPlatformFileBasedContentType\Fixtures;
+
+use BD\EzPlatformFileBasedContentType\ContentTypeProvider;
+use eZ\Publish\SPI;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+
+class BlogPostContentType implements ContentTypeProvider
+{
+    public function getType()
+    {
+        $type = new SPI\Persistence\Content\Type();
+
+        $type->id = 18;
+        $type->status = SPI\Persistence\Content\Type::STATUS_DEFINED;
+        $type->name = ['eng-GB' => 'Blog post'];
+        $type->description = ['eng-GB' => 'A Blog post written by an author'];
+        $type->identifier = 'blog_post';
+        $type->created = 1528882990;
+        $type->modified = 1528882990;
+        $type->creatorId = '14';
+        $type->modifierId = '14';
+        $type->remoteId = 'b9dfe86b6188e504d64f3369d29350d5';
+        $type->urlAliasSchema = null;
+        $type->nameSchema = '<short_title|title>';
+        $type->isContainer = false;
+        $type->initialLanguageId = 2;
+        $type->sortField = SPI\Persistence\Content\Location::SORT_FIELD_PUBLISHED;
+        $type->sortOrder = SPI\Persistence\Content\Location::SORT_ORDER_DESC;
+        $type->groupIds = [1];
+        $type->fieldDefinitions = [
+            $this->getTitleFieldDefinition(),
+        ];
+        $type->defaultAlwaysAvailable = false;
+
+        return $type;
+    }
+
+    private function getTitleFieldDefinition(): SPI\Persistence\Content\Type\FieldDefinition
+    {
+        $fieldDefinition = new SPI\Persistence\Content\Type\FieldDefinition();
+        $fieldDefinition->identifier = 'title';
+        $fieldDefinition->id = 185;
+        $fieldDefinition->name = ['eng-GB' => "Title"];
+        $fieldDefinition->position = 10;
+        $fieldDefinition->defaultValue = new FieldValue(['data' => 'default value']);
+        $fieldDefinition->fieldType = 'ezstring';
+        $fieldDefinition->isRequired = true;
+        $fieldDefinition->isTranslatable = 1;
+        $fieldDefinition->isSearchable = true;
+        $fieldDefinition->fieldGroup = 'content';
+        $fieldDefinition->fieldTypeConstraints = new SPI\Persistence\Content\FieldTypeConstraints([
+            'validators' => ['StringLengthValidator' => ['minStringLength' => 10, 'maxStringLength' => null]],
+        ]);
+
+        return $fieldDefinition;
+    }
+}
+


### PR DESCRIPTION
| Question | Answer |
| --------- | ------- |
| Status | Work in progress |
| Stories it implements | #3, #4 |

### Status
Content types can be loaded from files. Field Definitions haven't been tested / documented / implemented yet. Creating content won't be possible as fields can't be defined

### Usage
File Based Content Types are defined as a `ContentTypeProvider` [(example with `BlogPostContentType`)](https://github.com/bdunogier/ezplatform-filebased-contenttypes/blob/prototype1/tests/Fixtures/BlogPostContentType.php), defined as a service tagged with `ezplatform.content_type_provider`.

Example using `AppBundle` and, and automatic tagging of classes in `src/AppBundle/Platform/ContentTypes/`.

In `app/config/services.yml`:

```yaml
services:
  _defaults:
    AppBundle\Platform\ContentTypes\:
      resource: '../../src/AppBundle/Platform/ContentTypes/*'
      tags: [ezplatform.content_type_provider]
```

Types are created in `src/AppBundle/Platform/ContentTypes/`. The [`BlogPostContentType`](https://github.com/bdunogier/ezplatform-filebased-contenttypes/blob/prototype1/tests/Fixtures/BlogPostContentType.php) class in the test fixtures can be used as an example.

### Tasks
- [x] Cover Fields Definitions.
- [ ] (partially done) Handle content type ids: should something be registered in the database the first time such a content type is loaded ? The id could be stored, with minimal data, and the Handler could complete it with the object.